### PR TITLE
feat: update question base interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ print(question.getTemplateParameters())
   - Логика проверки кода.
   - Параметры: Код студента (строка).
   - Возвращаемое значение: `Result.Ok` - тесты пройдены, `Result.Fail` - не прошёл тест-кейс.
-  - Вызывает исключения: `SyntaxError`, `CompileError`, `RuntimeError`
+  - Вызывает исключения: `SyntaxError`, `CompileError`
 
 - `runTest(self, code: str) -> str`:
   - Запуск проверки кода и подсчёта процента коментариев в коде

--- a/src/prog_questions/QuestionBase.py
+++ b/src/prog_questions/QuestionBase.py
@@ -20,6 +20,10 @@ class Result(ABC):
         got: str
 
 
+class CompileError(Exception):
+    pass
+
+
 class QuestionBase(ABC):
     questionName: str = ''
     '''

--- a/src/prog_questions/QuestionBase.py
+++ b/src/prog_questions/QuestionBase.py
@@ -11,13 +11,28 @@ from .utility import CommentMetric
 class Result(ABC):
     @dataclass(frozen=True)
     class Ok:
+        '''
+        Успешный результат запуска
+        '''
         pass
 
     @dataclass(frozen=True)
     class Fail:
+        '''
+        Тест-кейс не пройден во время запуска
+        '''
         input: str
+        '''
+        Входные данные
+        '''
         expected: str
+        '''
+        Ожидаемый вывод
+        '''
         got: str
+        '''
+        Полеченный вывод
+        '''
 
 
 class CompileError(Exception):

--- a/src/prog_questions/QuestionBase.py
+++ b/src/prog_questions/QuestionBase.py
@@ -1,8 +1,23 @@
 from abc import ABC, abstractmethod
+from typing import final
+from dataclasses import dataclass
 from types import EllipsisType
 import sys
 import json
 from .utility import CommentMetric
+
+
+@final
+class Result(ABC):
+    @dataclass(frozen=True)
+    class Ok:
+        pass
+
+    @dataclass(frozen=True)
+    class Fail:
+        input: str
+        expected: str
+        got: str
 
 
 class QuestionBase(ABC):

--- a/src/prog_questions/QuestionBase.py
+++ b/src/prog_questions/QuestionBase.py
@@ -21,6 +21,9 @@ class Result(ABC):
 
 
 class CompileError(Exception):
+    '''
+    Общая ошибка компиляции
+    '''
     pass
 
 

--- a/src/prog_questions/QuestionBase.py
+++ b/src/prog_questions/QuestionBase.py
@@ -132,7 +132,7 @@ class QuestionBase(ABC):
                 output['epiloguehtml'] = f'<p>Процент комментариев: {commentsPercent}%</p>'
             else:
                 output['prologuehtml'] = '<h1>Тесты не пройдены</h1>'
-                output['testresults'] = [['iscorrect', 'Ввод', 'Ожидаемый', 'Получено', 'iscorrect'], [success, result.input, result.got, result.expected, success]]
+                output['testresults'] = [['iscorrect', 'Ввод', 'Ожидаемый', 'Получено', 'iscorrect'], [success, result.input, result.expected, result.got, success]]
 
         except SyntaxError as e:
             output['prologuehtml'] = f'<h1>Ошибка синтаксиса</h1><code>{str(e)}</code>'

--- a/src/prog_questions/QuestionBase.py
+++ b/src/prog_questions/QuestionBase.py
@@ -12,14 +12,15 @@ class Result(ABC):
     @dataclass(frozen=True)
     class Ok:
         '''
-        Успешный результат запуска
+        Успешный результат запуска проверки кода
         '''
         pass
 
     @dataclass(frozen=True)
     class Fail:
         '''
-        Тест-кейс не пройден во время запуска
+        Тест-кейс не пройден во время проверки кода.
+
         '''
         input: str
         '''
@@ -31,7 +32,7 @@ class Result(ABC):
         '''
         got: str
         '''
-        Полеченный вывод
+        Полученный вывод
         '''
 
 
@@ -127,24 +128,24 @@ class QuestionBase(ABC):
             success = isinstance(result, Result.Ok)
 
             if success:
-                output['prologuehtml'] = '<h1>Всё хорошо</h1>'
+                output['prologuehtml'] = '<h4>Всё хорошо</h4>'
                 commentsPercent = CommentMetric(code).get_comment_percentage()
                 output['epiloguehtml'] = f'<p>Процент комментариев: {commentsPercent}%</p>'
             else:
-                output['prologuehtml'] = '<h1>Тесты не пройдены</h1>'
+                output['prologuehtml'] = '<h4>Тесты не пройдены</h4>'
                 output['testresults'] = [['iscorrect', 'Ввод', 'Ожидаемый', 'Получено', 'iscorrect'], [success, result.input, result.expected, result.got, success]]
 
         except SyntaxError as e:
-            output['prologuehtml'] = f'<h1>Ошибка синтаксиса</h1><code>{str(e)}</code>'
+            output['prologuehtml'] = f'<h4>Ошибка синтаксиса</h4><p>{str(e)}</p>'
 
         except CompileError as e:
-            output['prologuehtml'] = f'<h1>Ошибка компиляции</h1><code>{str(e)}</code>'
+            output['prologuehtml'] = f'<h4>Ошибка компиляции</h4><p>{str(e)}</p>'
 
         except RuntimeError as e:
-            output['prologuehtml'] = f'<h1>Ошибка выполнения</h1><code>{str(e)}</code>'
+            output['prologuehtml'] = f'<h4>Ошибка выполнения</h4><p>{str(e)}</p>'
 
         except Exception:
-            output['prologuehtml'] = f'<h1>Ошибка задания</h1><p>Пожалуйста, свяжитесь с преподавателем (seed задания: {self.seed})</p>'
+            output['prologuehtml'] = f'<h4>Ошибка задания</h4><p>Пожалуйста, свяжитесь с преподавателем (seed задания: {self.seed})</p>'
 
         output['fraction'] = 1.0 if success else 0.0
         return json.dumps(output)

--- a/src/prog_questions/QuestionBase.py
+++ b/src/prog_questions/QuestionBase.py
@@ -109,7 +109,7 @@ class QuestionBase(ABC):
         Логика проверки кода
         code - код, отправленный студентом на проверку
         Возвращаемое значение - Result.Ok - всё хорошо, Result.Fail - не прошёл тест-кейс
-        Вызывает исключения: SyntaxError, CompileError, RuntimeError
+        Вызывает исключения: SyntaxError, CompileError
         '''
         ...
 
@@ -140,9 +140,6 @@ class QuestionBase(ABC):
 
         except CompileError as e:
             output['prologuehtml'] = f'<h4>Ошибка компиляции</h4><p>{str(e)}</p>'
-
-        except RuntimeError as e:
-            output['prologuehtml'] = f'<h4>Ошибка выполнения</h4><p>{str(e)}</p>'
 
         except Exception:
             output['prologuehtml'] = f'<h4>Ошибка задания</h4><p>Пожалуйста, свяжитесь с преподавателем (seed задания: {self.seed})</p>'


### PR DESCRIPTION
# Что нужно менять в вопросах

 - `QuestionBase.test` - нужно сообщить, что все тесты прошли успешно
   - Было: `return 'OK`
   - Стало: `return Result.Ok()`
 - `QuestionBase.test` - нужно сообщить, что на тест-кейс программа выдала неправильный результат
   - Было: `return 'Какая-то строка в которой собрана вся информация и тд...'`
   - Стало: `return Result.Fail('Входные данные', 'Ожидаемый результат', 'Полученный результат')`
 - `QuestionBase.test` - нужно отловить ошибку компиляции или ошибку синтаксиса от, например, `CProgramRunner`:
   - Было: делать это руками через `try: ... except CompilationError: ...`
   - Стало: можно не ловить, это делается уровнем выше централизованно
   - P.S. это работает конкретно для ошибки компиляции и синтаксиса. Если программа студента выдаёт ошибку во время выполнения, то это ловится руками и сообщается об ошибке вверх через `return Result.Fail(...)`

# Что нужно менять в `CProgramRunner`

- Конкретно ошибку синтаксиса унаследовать от встроенной `SyntaxError` (это по возможности, можно рассматривать это как ошибку компиляции)
- Конкретно ошибку компиляции унаследовать от описанной `CompilationError`, в сообщение ошибке ложить строку, что собственно случилось

# Что нужно менять в тестах
Заменить `'Ok'` на `Result.Ok()`, этого должно быть достаточно